### PR TITLE
fix(lf): solucionando problema de lf

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -17,5 +17,6 @@
   "requirePragma": false,
   "tabWidth": 2,
   "useTabs": false,
-  "embeddedLanguageFormatting": "auto"
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf"
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,8 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      'linebreak-style': ['error', 'unix']
     }
   },
   eslintNestJs.configs.flatRecommended


### PR DESCRIPTION
### Descripción

Esta PR soluciona el problema de los caracteres `␍` (retorno de carro) en los archivos del proyecto. Se ha configurado **Prettier** y **ESLint** para usar saltos de línea **LF** (`\n`) en lugar de **CRLF** (`\r\n`). Se ha modificado la configuración de Prettier para establecer la opción `endOfLine` a `"lf"`, y se ha añadido la regla `linebreak-style` en ESLint para forzar el uso de saltos de línea **Unix**.

### Tipo de Cambio

Marca con una "X" los tipos de cambios que has realizado:

- [X] Bugfix
- [ ] Nueva funcionalidad
- [ ] Mejora de rendimiento
- [ ] Refactorización de código
- [ ] Cambio en la documentación

### ¿Qué problema resuelve esta PR?

Esta PR resuelve el problema de los caracteres `␍` que aparecían en los archivos debido a los saltos de línea **CRLF**. La solución garantiza que todos los archivos usen saltos de línea **LF** (`\n`), evitando inconsistencias y errores de formateo en diferentes entornos de desarrollo.

### ¿Cómo has probado los cambios?

Los cambios se han probado ejecutando **Prettier** (`npm run format`) y **ESLint** (`npm run lint`) para asegurar que todos los archivos sigan las reglas de formateo configuradas. Además, se revisó manualmente el código para verificar que los caracteres `␍` hayan sido eliminados y que los saltos de línea sean consistentes.

### Checklist

Marca con una "X" los elementos que has completado antes de enviar la PR:

- [X] He revisado el código en busca de errores.
- [ ] He añadido pruebas para los cambios que realicé.
- [X] La documentación está actualizada si es necesario.
- [X] He probado los cambios localmente.
- [X] El código sigue las guías de estilo del proyecto.

### Notas Adicionales

Se ha configurado Prettier con `endOfLine: "lf"` y ESLint con la regla `linebreak-style: ["error", "unix"]` para asegurar que todos los archivos usen saltos de línea **LF** en lugar de **CRLF**. Esto resuelve el problema de los caracteres `␍` y mejora la coherencia del código en el proyecto.